### PR TITLE
Correct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This python module provides simple synchronization and data transfer mechanisms 
 
 Information about this module can be found here:
 
-* [github.org](https://github.com/jkpubsrc/python-module-jk-interprocesssync)
+* [github.com](https://github.com/jkpubsrc/python-module-jk-interprocessync)
 * [pypi.python.org](https://pypi.python.org/pypi/jk_interprocesssync)
 
 Why this module?

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This python module provides simple synchronization and data transfer mechanisms 
 Information about this module can be found here:
 
 * [github.com](https://github.com/jkpubsrc/python-module-jk-interprocessync)
-* [pypi.python.org](https://pypi.python.org/pypi/jk_interprocesssync)
+* [pypi.org](https://pypi.org/project/jk-interprocesssync/)
 
 Why this module?
 ----------------


### PR DESCRIPTION
Note, that the GitHub repo name has 2 's' `interprocessync`, while the description and PyPI package have 3 `interprocesssync`.